### PR TITLE
Update src/watson/backends.py

### DIFF
--- a/src/watson/backends.py
+++ b/src/watson/backends.py
@@ -205,7 +205,7 @@ class PostgresSearchBackend(SearchBackend):
             CREATE INDEX watson_searchentry_search_tsv ON watson_searchentry USING gin(search_tsv);
 
             -- Create the trigger function.
-            CREATE FUNCTION watson_searchentry_trigger_handler() RETURNS trigger AS $$
+            CREATE OR REPLACE FUNCTION watson_searchentry_trigger_handler() RETURNS trigger AS $$
             begin
                 new.search_tsv :=
                     setweight(to_tsvector('{search_config}', coalesce(new.title, '')), 'A') ||


### PR DESCRIPTION
CREATE OR REPLACE watson_searchentry_trigger_handler function to avoid problems with broken installs. 

Stops this error when reinstalling:

django.db.utils.DatabaseError: function "watson_searchentry_trigger_handler" already exists with same argument types
