### PR TITLE
PendingDeprecationWarning: django.utils.simplejson is deprecated; use json instead.

### DIFF
--- a/src/watson/models.py
+++ b/src/watson/models.py
@@ -1,10 +1,9 @@
 """Models used by django-watson."""
 
+import json
 from django.db import models
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.contenttypes import generic
-from django.utils import simplejson as json
-
 
 def has_int_pk(model):
     """Tests whether the given model has an integer primary key."""

--- a/src/watson/registration.py
+++ b/src/watson/registration.py
@@ -1,6 +1,7 @@
 """Adapters for registering models with django-watson."""
 
 import sys
+import json
 from itertools import chain
 from threading import local
 from functools import wraps
@@ -16,7 +17,6 @@ from django.db.models.query import QuerySet
 from django.db.models.signals import post_save, pre_delete
 from django.utils.html import strip_tags
 from django.utils.importlib import import_module
-from django.utils import simplejson as json
 
 from watson.models import SearchEntry, has_int_pk
 

--- a/src/watson/tests.py
+++ b/src/watson/tests.py
@@ -7,6 +7,7 @@ these tests have been amended to 'fooo' and 'baar'. Ho hum.
 """
 
 import os
+import json
 from unittest import skipUnless
 
 from django.db import models
@@ -18,7 +19,6 @@ from django.contrib import admin
 from django.contrib.auth.models import User
 from django.http import HttpResponseNotFound, HttpResponseServerError
 from django import template
-from django.utils import simplejson as json
 
 import watson
 from watson.registration import RegistrationError, get_backend, SearchEngine

--- a/src/watson/views.py
+++ b/src/watson/views.py
@@ -1,8 +1,8 @@
 """Views used by the built-in site search functionality."""
 
+import json
 from django.shortcuts import redirect
 from django.http import HttpResponse
-from django.utils import simplejson as json
 from django.views import generic
 from django.views.generic.list import BaseListView
 


### PR DESCRIPTION
Django 1.5 deprecates django.utils.simplejson in favor of json, and raises deprecation warnings. See:

https://docs.djangoproject.com/en/dev/releases/1.5/#system-version-of-simplejson-no-longer-used
