### PR TITLE
Row-level (or per instance) language specification for FTS

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -13,28 +13,30 @@ Features
 * Order results by by relevance.
 * No need to install additional third-party modules or services.
 * Fast and scaleable enough for most use cases.
+* UPDATED: Can consider search config on row-level if there is column with language information (for PostgreSQL only)
 
 
 Documentation
 -------------
 
-Please read the [Getting Started][] guide for more information.
-
-[Getting Started]: https://github.com/etianen/django-watson/wiki
-    "Getting started with django-watson"
-    
-Download instructions, bug reporting and links to full documentation can be
-found at the [main project website][].
+Please read the docs for main project first:
 
 [main project website]: http://github.com/etianen/django-watson
     "django-watson on GitHub"
 
-You can keep up to date with the latest announcements by joining the
-[django-watson discussion group][].
+After installation register model with 
 
-[django-watson discussion group]: http://groups.google.com/group/django-watson
-    "django-watson Google Group"
+watson.register(Model, search_config='search_language')
 
+where search_config point to model's field with language name ('english', 'russian', etc., like in pg_catalog.*)
+Now you should be able to do search your model with or without search_config specified in your view, just like:
+
+            if request.LANGUAGE_CODE == 'ru':
+                results = watson.search(query, models=(my_model,), search_config='russian')
+            else:
+                results = watson.search(query, models=(my_model,))
+
+filter() is search_config aware too.
     
 More information
 ----------------
@@ -44,10 +46,3 @@ from the [django-watson project site][].
 
 [django-watson project site]: http://github.com/etianen/django-watson
     "django-watson on GitHub"
-    
-Dave Hall is a freelance web developer, based in Cambridge, UK. You can usually
-find him on the Internet in a number of different places:
-
-*   [Website](http://www.etianen.com/ "Dave Hall's homepage")
-*   [Twitter](http://twitter.com/etianen "Dave Hall on Twitter")
-*   [Google Profile](http://www.google.com/profiles/david.etianen "Dave Hall's Google profile")

--- a/src/watson/management/commands/downgradewatson.py
+++ b/src/watson/management/commands/downgradewatson.py
@@ -1,0 +1,29 @@
+"""Rolls back the database trigger to old fashion."""
+
+from __future__ import unicode_literals
+
+from django.core.management.base import NoArgsCommand
+from django.db import transaction
+
+from watson.registration import get_backend
+
+
+class Command(NoArgsCommand):
+
+    help = "Rolls back the database trigger to old fashion."
+    
+    @transaction.commit_on_success
+    def handle_noargs(self, **options):
+        """Runs the management command."""
+        verbosity = int(options.get("verbosity", 1))
+        backend = get_backend()
+        if not backend.requires_installation:
+            if verbosity >= 2:
+                self.stdout.write("Your search backend does not require installation.\n")
+        elif backend.is_upgraded():
+            backend.do_downgrade()
+            if verbosity >= 2:
+                self.stdout.write("django-watson has been successfully downgraded.\n")
+        else:
+            if verbosity >= 2:
+                self.stdout.write("django-watson is not upgraded.\n")

--- a/src/watson/management/commands/upgradewatson.py
+++ b/src/watson/management/commands/upgradewatson.py
@@ -1,0 +1,29 @@
+"""Upgrades the database trigger needed by django-watson for multilanguage tables."""
+
+from __future__ import unicode_literals
+
+from django.core.management.base import NoArgsCommand
+from django.db import transaction
+
+from watson.registration import get_backend
+
+
+class Command(NoArgsCommand):
+
+    help = "Upgrades the database trigger needed by django-watson for multilanguage tables."
+    
+    @transaction.commit_on_success
+    def handle_noargs(self, **options):
+        """Runs the management command."""
+        verbosity = int(options.get("verbosity", 1))
+        backend = get_backend()
+        if not backend.requires_upgrade:
+            if verbosity >= 2:
+                self.stdout.write("Your search backend does not require upgrade.\n")
+        elif backend.is_upgraded():
+            if verbosity >= 2:
+                self.stdout.write("django-watson is already upgraded.\n")
+        else:
+            backend.do_upgrade()
+            if verbosity >= 2:
+                self.stdout.write("django-watson has been successfully upgraded.\n")

--- a/src/watson/migrations/0003_auto__add_field_searchentry_search_config.py
+++ b/src/watson/migrations/0003_auto__add_field_searchentry_search_config.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'SearchEntry.search_config'
+        db.add_column('watson_searchentry', 'search_config',
+                      self.gf('django.db.models.fields.CharField')(default='english', max_length=24),
+                      keep_default=False)
+
+    def backwards(self, orm):
+        # Deleting field 'SearchEntry.search_config'
+        db.delete_column('watson_searchentry', 'search_config')
+
+    models = {
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'watson.searchentry': {
+            'Meta': {'object_name': 'SearchEntry'},
+            'content': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'engine_slug': ('django.db.models.fields.CharField', [], {'default': "'default'", 'max_length': '200', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'meta_encoded': ('django.db.models.fields.TextField', [], {}),
+            'object_id': ('django.db.models.fields.TextField', [], {}),
+            'object_id_int': ('django.db.models.fields.IntegerField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'}),
+            'search_config': ('django.db.models.fields.CharField', [], {'default': "'english'", 'max_length': '24'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '1000'}),
+            'url': ('django.db.models.fields.CharField', [], {'max_length': '1000', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['watson']

--- a/src/watson/migrations/0004_upgradewatson.py
+++ b/src/watson/migrations/0004_upgradewatson.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+from django.core.management import call_command
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        call_command("upgradewatson", verbosity=0)
+
+    def backwards(self, orm):
+        call_command("downgradewatson", verbosity=0)
+
+    models = {
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'watson.searchentry': {
+            'Meta': {'object_name': 'SearchEntry'},
+            'content': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'engine_slug': ('django.db.models.fields.CharField', [], {'default': "'default'", 'max_length': '200', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'meta_encoded': ('django.db.models.fields.TextField', [], {}),
+            'object_id': ('django.db.models.fields.TextField', [], {}),
+            'object_id_int': ('django.db.models.fields.IntegerField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'}),
+            'search_config': ('django.db.models.fields.CharField', [], {'default': "'english'", 'max_length': '24'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '1000'}),
+            'url': ('django.db.models.fields.CharField', [], {'max_length': '1000', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['watson']

--- a/src/watson/models.py
+++ b/src/watson/models.py
@@ -67,6 +67,11 @@ class SearchEntry(models.Model):
     
     meta_encoded = models.TextField()
     
+    search_config = models.CharField(
+        max_length = 24,
+        default = 'english'
+    )
+
     @property
     def meta(self):
         """Returns the meta information stored with the search entry."""


### PR DESCRIPTION
This patch allows to use some field in base model to be considered by watson for creating ts_vector. This gives ability to use different languages for different instances of base model.
For example:

```
class MyModel(models.Model):
    search_language = models.CharField(_("Language for search index"),
                                                          max_length=24,
                                                          default="russian")
   content = models.TextField()

watson.register(MyModel, search_config='search_language')
```

then we can use watson.search() and filter() with search_config paramer for particuar searching, e.g. in some view:

```
if request.LANGUAGE_CODE == 'ru':
    res = watson.search(query, models=(model,), search_config='russian')
else:
    res = watson.search(query, models=(model,))  # for default search config
```

NOTE: There isn't any tests yet, but code was checked on sample data.
Please review this code
