### PR TITLE
[Google Like Advanced Search]

### DIFF
--- a/src/watson/registration.py
+++ b/src/watson/registration.py
@@ -526,7 +526,7 @@ class SearchEngine(object):
         # Return the complete queryset.
         return queryset
         
-    def filter(self, queryset, search_text, ranking=True):
+    def filter(self, queryset, search_text, ranking=True, advanced_search=False):
         """
         Filters the given model or queryset using the given text, returning the
         modified queryset.
@@ -540,7 +540,7 @@ class SearchEngine(object):
             return queryset
         # Perform the backend-specific full text match.
         backend = get_backend()
-        queryset = backend.do_filter(self._engine_slug, queryset, search_text)
+        queryset = backend.do_filter(self._engine_slug, queryset, search_text, advanced_search)
         # Perform the backend-specific full-text ranking.
         if ranking:
             queryset = backend.do_filter_ranking(self._engine_slug, queryset, search_text)


### PR DESCRIPTION
```
COMPLETED:
    I just added some google like advanced search features like:
        a. You can now search for "quoted multi word text";
        b. You can now exclude undesired results using the minus before a word, for example: google news -glass;
        c. The minus is also available for the quoted text: -"google news" glass;
        d. If no quotes or minus are provided, the behaviour should be exactly like before;

    To make the interface, I added a advanced_search=False parameter to the filter function.

PENDING:
    Implement the advanced search to the watson.search function
```
