### PR TITLE
get() should accept *args and **kwargs

### DIFF
--- a/src/watson/views.py
+++ b/src/watson/views.py
@@ -72,14 +72,14 @@ class SearchMixin(object):
             context[key] = value
         return context
     
-    def get(self, request):
+    def get(self, request, *args, **kwargs):
         """Performs a GET request."""
         self.query = self.get_query(request)
         if not self.query:
             empty_query_redirect = self.get_empty_query_redirect()
             if empty_query_redirect:
                 return redirect(empty_query_redirect)
-        return super(SearchMixin, self).get(request)
+        return super(SearchMixin, self).get(request, *args, **kwargs)
 
 
 class SearchView(SearchMixin, generic.ListView):


### PR DESCRIPTION
Using groups (named or otherwise) in URL regex results in them being passed to get() as arguments. This patch makes SearchMixin.get() accept them.

Without this patch, you get the following TypeError:
`get() got an unexpected keyword argument 'q'`
