### PR TITLE
fixed django 1.8 get_query_set deprecation warning

### DIFF
--- a/src/watson/admin.py
+++ b/src/watson/admin.py
@@ -14,14 +14,14 @@ admin_search_engine = SearchEngine("admin")
 class WatsonSearchChangeList(ChangeList):
 
     """A change list that takes advantage of django-watson full text search."""
-        
-    def get_query_set(self, *args, **kwargs):
+
+    def get_queryset(self, *args, **kwargs):
         """Creates the query set."""
         # Do the basic searching.
         search_fields = self.search_fields
         self.search_fields = ()
         try:
-            qs = super(WatsonSearchChangeList, self).get_query_set(*args, **kwargs)
+            qs = super(WatsonSearchChangeList, self).get_queryset(*args, **kwargs)
         finally:
             self.search_fields = search_fields
         # Do the full text searching.
@@ -34,20 +34,20 @@ class SearchAdmin(admin.ModelAdmin):
 
     """
     A ModelAdmin subclass that provides full-text search integration.
-    
+
     Subclass this admin class and specify a tuple of search_fields for instant
     integration!
     """
-    
+
     search_engine = admin_search_engine
-    
+
     search_adapter_cls = SearchAdapter
-    
+
     @property
     def search_context_manager(self):
         """The search context manager used by this SearchAdmin."""
         return self.search_engine._search_context_manager
-    
+
     def __init__(self, *args, **kwargs):
         """Initializes the search admin."""
         super(SearchAdmin, self).__init__(*args, **kwargs)
@@ -62,7 +62,7 @@ class SearchAdmin(admin.ModelAdmin):
         self.change_view = self.search_context_manager.update_index()(self.change_view)
         self.delete_view = self.search_context_manager.update_index()(self.delete_view)
         self.changelist_view = self.search_context_manager.update_index()(self.changelist_view)
-    
+
     def register_model_with_watson(self):
         """Registers this admin class' model with django-watson."""
         if not self.search_engine.is_registered(self.model) and self.search_fields:
@@ -72,7 +72,7 @@ class SearchAdmin(admin.ModelAdmin):
                 adapter_cls = self.search_adapter_cls,
                 get_live_queryset = lambda self_: None,  # Ensure complete queryset is used in admin.
             )
-    
+
     def get_changelist(self, request, **kwargs):
         """Returns the ChangeList class for use on the changelist page."""
         return WatsonSearchChangeList


### PR DESCRIPTION
When using with django 1.7 this warning always was shown:

/usr/local/lib/python2.7/dist-packages/watson/admin.py:14: RemovedInDjango18Warning: `WatsonSearchChangeList.get_query_set` method should be renamed `get_queryset`.
