### PR TITLE
Issue #94: Accessing app_label and model_name through content type rather than object

### DIFF
--- a/src/watson/templatetags/watson.py
+++ b/src/watson/templatetags/watson.py
@@ -24,14 +24,14 @@ def search_results(context, search_results):
         return template.loader.render_to_string("watson/includes/search_results.html", context)
     finally:
         context.pop()
-    
-    
+
+
 @register.simple_tag(takes_context=True)
 def search_result_item(context, search_result):
     obj = search_result.object
     params = {
-        "app_label": obj._meta.app_label,
-        "model_name": obj.__class__.__name__.lower(),
+        "app_label": search_result.content_type.app_label,
+        "model_name": search_result.content_type.model,
     }
     # Render the template.
     context.push()

--- a/src/watson/templatetags/watson.py
+++ b/src/watson/templatetags/watson.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals
 
 from django import template
+from django.contrib.contenttypes.models import ContentType
 
 
 register = template.Library()
@@ -29,9 +30,11 @@ def search_results(context, search_results):
 @register.simple_tag(takes_context=True)
 def search_result_item(context, search_result):
     obj = search_result.object
+    content_type = ContentType.objects.get_for_id(search_result.content_type_id)
+
     params = {
-        "app_label": search_result.content_type.app_label,
-        "model_name": search_result.content_type.model,
+        "app_label": content_type.app_label,
+        "model_name": content_type.model,
     }
     # Render the template.
     context.push()


### PR DESCRIPTION
As the object property is not always loaded by prefetch_related(), the `search_result_item` template tag will raise an AttributeError. But, as the object is essentially used for populating the string format params dict, it is possible to instead use the content type object (which appears to be available even when object is missing) for getting the `app_label` and `model_name` strings.

The only drawback is that the `obj` template variable may be `None` in some instances. It is not accessed in any standard tempaltes, and this issue would have caused an AttributeError earlier anyway.