### PR TITLE
allow custom json dumping for meta

### DIFF
--- a/src/watson/models.py
+++ b/src/watson/models.py
@@ -75,7 +75,7 @@ class SearchEntry(models.Model):
     def _deserialize_meta(self):
         from watson.registration import SearchEngine
         engine = SearchEngine._created_engines[self.engine_slug]
-        model = self.content_type.model_class()
+        model = ContentType.objects.get_for_id(self.content_type_id).model_class()
         adapter = engine.get_adapter(model)
         return adapter.deserialize_meta(self.meta_encoded)
 

--- a/src/watson/models.py
+++ b/src/watson/models.py
@@ -70,6 +70,9 @@ class SearchEntry(models.Model):
 
     meta_encoded = models.TextField()
 
+    def _deserialize_meta(self):
+        return json.loads(self.meta_encoded)
+
     @property
     def meta(self):
         """Returns the meta information stored with the search entry."""
@@ -77,7 +80,7 @@ class SearchEntry(models.Model):
         if hasattr(self, META_CACHE_KEY):
             return getattr(self, META_CACHE_KEY)
         # Decode the meta.
-        meta_value = json.loads(self.meta_encoded)
+        meta_value = self._deserialize_meta()
         setattr(self, META_CACHE_KEY, meta_value)
         return meta_value
 

--- a/src/watson/registration.py
+++ b/src/watson/registration.py
@@ -152,7 +152,7 @@ class SearchAdapter(object):
             for field_name in self.store
         )
 
-    def serialized_meta(self, obj):
+    def serialize_meta(self, obj):
         """serialise meta ready to be saved in "meta_encoded"."""
         meta_obj = self.get_meta(obj)
         return json.dumps(meta_obj, cls=DjangoJSONEncoder)
@@ -465,7 +465,7 @@ class SearchEngine(object):
             "description": adapter.get_description(obj),
             "content": adapter.get_content(obj),
             "url": adapter.get_url(obj),
-            "meta_encoded": adapter.serialized_meta(obj),
+            "meta_encoded": adapter.serialize_meta(obj),
         }
         # Try to get the existing search entry.
         object_id_int, search_entries = self._get_entries_for_obj(obj)


### PR DESCRIPTION
currently if you want to customise the behaviour of the json dump method you would have to either:
* overwrite the whole of `_update_obj_index_iter`
* or do something ugly like `return json.loads(json.dumps(meta, cls=CustomerEncoder))` at the end of `get_meta`.

This is particularly useful for things like lazy translations or `Decimal`s where customer encoders can be very helpful in JSONifying data.

If you think this makes sense, I can also add:
* tests. There are currently no tests for customer adapers, and this should have full coverage but proper tests would be good.
* a simple default encoder which works for common django objects?