### PR TITLE
Experimental trigram support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,20 @@ python:
 env:
   - DJANGO=django==1.6.11
   - DJANGO=django==1.6.11 DB_ENGINE="django.db.backends.postgresql_psycopg2" DB_NAME="test_project" DB_USER="postgres"
+  - DJANGO=django==1.6.11 DB_ENGINE="django.db.backends.postgresql_psycopg2" DB_NAME="test_project" DB_USER="postgres"
+                          SEARCH_BACKEND="watson.backends.TrigramPostgresSearchBackend"
   - DJANGO=django==1.6.11 DB_ENGINE="django.db.backends.mysql" DB_NAME="test_project" DB_USER="travis"
   - DJANGO=django==1.7.7
   - DJANGO=django==1.7.7 DB_ENGINE="django.db.backends.postgresql_psycopg2" DB_NAME="test_project" DB_USER="postgres"
+  - DJANGO=django==1.7.7 DB_ENGINE="django.db.backends.postgresql_psycopg2" DB_NAME="test_project" DB_USER="postgres"
+                         SEARCH_BACKEND="watson.backends.TrigramPostgresSearchBackend"
   - DJANGO=django==1.7.7 DB_ENGINE="django.db.backends.mysql" DB_NAME="test_project" DB_USER="travis"
   - DJANGO=django==1.8.1
   - DJANGO=django==1.8.1 DB_ENGINE="django.db.backends.postgresql_psycopg2" DB_NAME="test_project" DB_USER="postgres"
+  - DJANGO=django==1.8.1 DB_ENGINE="django.db.backends.postgresql_psycopg2" DB_NAME="test_project" DB_USER="postgres"
+                         SEARCH_BACKEND="watson.backends.TrigramPostgresSearchBackend"
   - DJANGO=django==1.8.1 DB_ENGINE="django.db.backends.mysql" DB_NAME="test_project" DB_USER="travis"
+
 matrix:
   exclude:
     # Django >= 1.7 does not work with Python 2.6.
@@ -25,12 +32,14 @@ matrix:
       env: DJANGO=django==1.7.7 DB_ENGINE="django.db.backends.postgresql_psycopg2" DB_NAME="test_project" DB_USER="postgres"
     - python: 2.6
       env: DJANGO=django==1.7.7 DB_ENGINE="django.db.backends.mysql" DB_NAME="test_project" DB_USER="travis"
+
     - python: 2.6
       env: DJANGO=django==1.8.1
     - python: 2.6
       env: DJANGO=django==1.8.1 DB_ENGINE="django.db.backends.postgresql_psycopg2" DB_NAME="test_project" DB_USER="postgres"
     - python: 2.6
       env: DJANGO=django==1.8.1 DB_ENGINE="django.db.backends.mysql" DB_NAME="test_project" DB_USER="travis"
+
     # mysqlclient does not work with Python 2.6 or 3.2.
     - python: 2.6
       env: DJANGO=django==1.6.11 DB_ENGINE="django.db.backends.mysql" DB_NAME="test_project" DB_USER="travis"

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 import os
-from distutils.core import setup
+from setuptools import setup
 
 
 setup(

--- a/src/tests/runtests.py
+++ b/src/tests/runtests.py
@@ -60,6 +60,7 @@ def main():
         USE_TZ = True,
         STATIC_URL = "/static/",
         TEST_RUNNER = "django.test.runner.DiscoverRunner",
+        WATSON_BACKEND = os.environ.get("SEARCH_BACKEND", None)
     )
     # Run Django setup (1.7+).
     import django

--- a/src/watson/backends.py
+++ b/src/watson/backends.py
@@ -1,22 +1,19 @@
 """Search backends used by django-watson."""
 
 from __future__ import unicode_literals
-
 import re, abc
-
 from django.contrib.contenttypes.models import ContentType
 from django.db import connection, transaction
 from django.db.models import Q
 from django.utils.encoding import force_text
 from django.utils import six
-
 from watson.models import SearchEntry, has_int_pk
 
 
 def regex_from_word(word):
     """Generates a regext from the given search word."""
     return "(\s{word})|(^{word})".format(
-        word = re.escape(word),
+        word=re.escape(word),
     )
 
 
@@ -32,48 +29,47 @@ def escape_query(text):
 
 
 class SearchBackend(six.with_metaclass(abc.ABCMeta)):
-
     """Base class for all search backends."""
-    
+
     def is_installed(self):
         """Checks whether django-watson is installed."""
         return True
-    
+
     def do_install(self):
         """Executes the SQL needed to install django-watson."""
         pass
-        
+
     def do_uninstall(self):
         """Executes the SQL needed to uninstall django-watson."""
         pass
-    
+
     requires_installation = False
-    
+
     supports_ranking = False
-    
+
     supports_prefix_matching = False
-        
+
     def do_search_ranking(self, engine_slug, queryset, search_text):
         """Ranks the given queryset according to the relevance of the given search text."""
         return queryset.extra(
-            select = {
+            select={
                 "watson_rank": "1",
             },
         )
-        
+
     @abc.abstractmethod
     def do_search(self, engine_slug, queryset, search_text):
         """Filters the given queryset according the the search logic for this backend."""
         raise NotImplementedError
-        
+
     def do_filter_ranking(self, engine_slug, queryset, search_text):
         """Ranks the given queryset according to the relevance of the given search text."""
         return queryset.extra(
-            select = {
+            select={
                 "watson_rank": "1",
             },
         )
-    
+
     @abc.abstractmethod
     def do_filter(self, engine_slug, queryset, search_text):
         """Filters the given queryset according the the search logic for this backend."""
@@ -81,11 +77,10 @@ class SearchBackend(six.with_metaclass(abc.ABCMeta)):
 
 
 class RegexSearchMixin(six.with_metaclass(abc.ABCMeta)):
-    
     """Mixin to adding regex search to a search backend."""
-    
+
     supports_prefix_matching = True
-    
+
     def do_search(self, engine_slug, queryset, search_text):
         """Filters the given queryset according the the search logic for this backend."""
         word_query = Q()
@@ -95,7 +90,7 @@ class RegexSearchMixin(six.with_metaclass(abc.ABCMeta)):
         return queryset.filter(
             word_query
         )
-        
+
     def do_filter(self, engine_slug, queryset, search_text):
         """Filters the given queryset according the the search logic for this backend."""
         model = queryset.model
@@ -109,7 +104,7 @@ class RegexSearchMixin(six.with_metaclass(abc.ABCMeta)):
         """, """
             ({db_table}.{content_type_id} = %s)
         """]
-        word_kwargs= {
+        word_kwargs = {
             "db_table": db_table,
             "model_db_table": model_db_table,
             "engine_slug": connection.ops.quote_name("engine_slug"),
@@ -145,19 +140,17 @@ class RegexSearchMixin(six.with_metaclass(abc.ABCMeta)):
         # Compile the query.
         full_word_query = " AND ".join(word_query).format(**word_kwargs)
         return queryset.extra(
-            tables = (db_table,),
-            where = (full_word_query,),
-            params = word_args,
+            tables=(db_table,),
+            where=(full_word_query,),
+            params=word_args,
         )
 
 
 class RegexSearchBackend(RegexSearchMixin, SearchBackend):
-    
     """A search backend that works with SQLite3."""
 
 
 class PostgresSearchBackend(SearchBackend):
-
     """A search backend that uses native PostgreSQL full text indices."""
 
     search_config = "pg_catalog.english"
@@ -170,7 +163,7 @@ class PostgresSearchBackend(SearchBackend):
             for word
             in escape_query(text).split()
         )
-    
+
     def is_installed(self):
         """Checks whether django-watson is installed."""
         cursor = connection.cursor()
@@ -179,7 +172,7 @@ class PostgresSearchBackend(SearchBackend):
             WHERE attrelid = (SELECT oid FROM pg_class WHERE relname = 'watson_searchentry') AND attname = 'search_tsv';
         """)
         return bool(cursor.fetchall())
-    
+
     @transaction.atomic()
     def do_install(self):
         """Executes the PostgreSQL specific SQL code to install django-watson."""
@@ -217,7 +210,7 @@ class PostgresSearchBackend(SearchBackend):
             CREATE TRIGGER watson_searchentry_trigger BEFORE INSERT OR UPDATE
             ON watson_searchentry FOR EACH ROW EXECUTE PROCEDURE watson_searchentry_trigger_handler();
         """.format(
-            search_config = self.search_config
+            search_config=self.search_config
         ))
 
     @transaction.atomic()
@@ -230,34 +223,34 @@ class PostgresSearchBackend(SearchBackend):
 
             DROP FUNCTION watson_searchentry_trigger_handler();
         """)
-        
+
     requires_installation = True
-    
+
     supports_ranking = True
-    
+
     supports_prefix_matching = True
-        
+
     def do_search(self, engine_slug, queryset, search_text):
         """Performs the full text search."""
         return queryset.extra(
-            where = ("search_tsv @@ to_tsquery('{search_config}', %s)".format(
-                search_config = self.search_config
+            where=("search_tsv @@ to_tsquery('{search_config}', %s)".format(
+                search_config=self.search_config
             ),),
-            params = (self.escape_postgres_query(search_text),),
+            params=(self.escape_postgres_query(search_text),),
         )
-        
+
     def do_search_ranking(self, engine_slug, queryset, search_text):
         """Performs full text ranking."""
         return queryset.extra(
-            select = {
+            select={
                 "watson_rank": "ts_rank_cd(watson_searchentry.search_tsv, to_tsquery('{search_config}', %s))".format(
-                    search_config = self.search_config
+                    search_config=self.search_config
                 ),
             },
-            select_params = (self.escape_postgres_query(search_text),),
-            order_by = ("-watson_rank",),
+            select_params=(self.escape_postgres_query(search_text),),
+            order_by=("-watson_rank",),
         )
-        
+
     def do_filter(self, engine_slug, queryset, search_text):
         """Performs the full text filter."""
         model = queryset.model
@@ -268,45 +261,124 @@ class PostgresSearchBackend(SearchBackend):
         else:
             ref_name = "object_id"
         return queryset.extra(
-            tables = ("watson_searchentry",),
-            where = (
+            tables=("watson_searchentry",),
+            where=(
                 "watson_searchentry.engine_slug = %s",
                 "watson_searchentry.search_tsv @@ to_tsquery('{search_config}', %s)".format(
-                    search_config = self.search_config
+                    search_config=self.search_config
                 ),
                 "watson_searchentry.{ref_name} = {table_name}.{pk_name}".format(
-                    ref_name = ref_name,
-                    table_name = connection.ops.quote_name(model._meta.db_table),
-                    pk_name = connection.ops.quote_name(pk.db_column or pk.attname),
+                    ref_name=ref_name,
+                    table_name=connection.ops.quote_name(model._meta.db_table),
+                    pk_name=connection.ops.quote_name(pk.db_column or pk.attname),
                 ),
                 "watson_searchentry.content_type_id = %s"
             ),
-            params = (engine_slug, self.escape_postgres_query(search_text), content_type.id),
+            params=(engine_slug, self.escape_postgres_query(search_text), content_type.id),
         )
-        
+
     def do_filter_ranking(self, engine_slug, queryset, search_text):
         """Performs the full text ranking."""
         return queryset.extra(
-            select = {
+            select={
                 "watson_rank": "ts_rank_cd(watson_searchentry.search_tsv, to_tsquery('{search_config}', %s))".format(
-                    search_config = self.search_config
+                    search_config=self.search_config
                 ),
             },
-            select_params = (self.escape_postgres_query(search_text),),
-            order_by = ("-watson_rank",),
+            select_params=(self.escape_postgres_query(search_text),),
+            order_by=("-watson_rank",),
         )
-        
-        
-class PostgresLegacySearchBackend(PostgresSearchBackend):
 
+
+class TrigramPostgresSearchBackend(PostgresSearchBackend):
+
+    @transaction.atomic()
+    def do_install(self):
+        """Executes the PostgreSQL specific SQL code to install django-watson."""
+        connection.cursor().execute("""
+        CREATE EXTENSION IF NOT EXISTS pg_trgm;
+        CREATE INDEX watson_searchentry_search_trgm ON watson_searchentry USING gin(content gin_trgm_ops, title gin_trgm_ops);
+        """)
+
+    @transaction.atomic()
+    def do_uninstall(self):
+        """Executes the PostgreSQL specific SQL code to uninstall django-watson."""
+        connection.cursor().execute("""
+            DROP INDEX watson_searchentry_search_trgm;
+        """)
+
+    def is_installed(self):
+        """Checks whether django-watson is installed."""
+        cursor = connection.cursor()
+        cursor.execute("""
+            SELECT indexname FROM pg_indexes WHERE indexname = 'watson_searchentry_search_trgm';
+        """)
+        return bool(cursor.fetchall())
+
+    def do_search(self, engine_slug, queryset, search_text):
+        """Performs the full text search."""
+        return queryset.extra(
+            where=("content %% %s",),
+            params=(self.escape_postgres_query(search_text),),
+        )
+
+    def do_search_ranking(self, engine_slug, queryset, search_text):
+        """Performs full text ranking."""
+        return queryset.extra(
+            select={
+                "watson_rank": "watson_searchentry.content <-> %s"
+            },
+            select_params=(self.escape_postgres_query(search_text),),
+            order_by=("-watson_rank",),
+        )
+
+    def do_filter(self, engine_slug, queryset, search_text):
+        """Performs the full text filter."""
+        model = queryset.model
+        content_type = ContentType.objects.get_for_model(model)
+        pk = model._meta.pk
+        if has_int_pk(model):
+            ref_name = "object_id_int"
+        else:
+            ref_name = "object_id"
+        return queryset.extra(
+            tables=("watson_searchentry",),
+            where=(
+                "watson_searchentry.engine_slug = %s",
+                "watson_searchentry.content %% %s",
+                "watson_searchentry.{ref_name} = {table_name}.{pk_name}".format(
+                    ref_name=ref_name,
+                    table_name=connection.ops.quote_name(model._meta.db_table),
+                    pk_name=connection.ops.quote_name(pk.db_column or pk.attname),
+                ),
+                "watson_searchentry.content_type_id = %s"
+            ),
+            params=(engine_slug, self.escape_postgres_query(search_text), content_type.id),
+        )
+
+    def do_filter_ranking(self, engine_slug, queryset, search_text):
+        """Performs the full text ranking."""
+        return queryset.extra(
+            select={
+                "watson_rank": "watson_searchentry.content <-> %s"
+            },
+            select_params=(self.escape_postgres_query(search_text),),
+            order_by=("-watson_rank",),
+        )
+
+    def escape_postgres_query(self, text):
+        return "$${0}$$".format(text)
+
+
+class PostgresLegacySearchBackend(PostgresSearchBackend):
     """
     A search backend that uses native PostgreSQL full text indices.
     
     This backend doesn't support prefix matching, and works with PostgreSQL 8.3 and below.
     """
-    
+
     supports_prefix_matching = False
-    
+
     def escape_postgres_query(self, text):
         """Escapes the given text to become a valid ts_query."""
         return " & ".join(
@@ -317,7 +389,6 @@ class PostgresLegacySearchBackend(PostgresSearchBackend):
 
 
 class PostgresPrefixLegacySearchBackend(RegexSearchMixin, PostgresLegacySearchBackend):
-    
     """
     A legacy search backend that uses a regexp to perform matches, but still allows
     relevance rankings.
@@ -330,14 +401,13 @@ class PostgresPrefixLegacySearchBackend(RegexSearchMixin, PostgresLegacySearchBa
 def escape_mysql_boolean_query(search_text):
     return " ".join(
         '+{word}*'.format(
-            word = word,
+            word=word,
         )
         for word in escape_query(search_text).split()
     )
 
 
 class MySQLSearchBackend(SearchBackend):
-
     def is_installed(self):
         """Checks whether django-watson is installed."""
         cursor = connection.cursor()
@@ -348,19 +418,21 @@ class MySQLSearchBackend(SearchBackend):
         """Executes the MySQL specific SQL code to install django-watson."""
         cursor = connection.cursor()
         # Drop all foreign keys on the watson_searchentry table.
-        cursor.execute("SELECT CONSTRAINT_NAME FROM information_schema.TABLE_CONSTRAINTS WHERE CONSTRAINT_SCHEMA = DATABASE() AND TABLE_NAME = 'watson_searchentry' AND CONSTRAINT_TYPE = 'FOREIGN KEY'")
+        cursor.execute(
+            "SELECT CONSTRAINT_NAME FROM information_schema.TABLE_CONSTRAINTS WHERE CONSTRAINT_SCHEMA = DATABASE() AND TABLE_NAME = 'watson_searchentry' AND CONSTRAINT_TYPE = 'FOREIGN KEY'")
         for constraint_name, in cursor.fetchall():
             cursor.execute("ALTER TABLE watson_searchentry DROP FOREIGN KEY {constraint_name}".format(
-                constraint_name = constraint_name,
+                constraint_name=constraint_name,
             ))
         # Change the storage engine to MyISAM.
         cursor.execute("ALTER TABLE watson_searchentry ENGINE = MyISAM")
         # Add the full text indexes.
-        cursor.execute("CREATE FULLTEXT INDEX watson_searchentry_fulltext ON watson_searchentry (title, description, content)")
+        cursor.execute(
+            "CREATE FULLTEXT INDEX watson_searchentry_fulltext ON watson_searchentry (title, description, content)")
         cursor.execute("CREATE FULLTEXT INDEX watson_searchentry_title ON watson_searchentry (title)")
         cursor.execute("CREATE FULLTEXT INDEX watson_searchentry_description ON watson_searchentry (description)")
         cursor.execute("CREATE FULLTEXT INDEX watson_searchentry_content ON watson_searchentry (content)")
-    
+
     def do_uninstall(self):
         """Executes the SQL needed to uninstall django-watson."""
         cursor = connection.cursor()
@@ -369,38 +441,38 @@ class MySQLSearchBackend(SearchBackend):
         cursor.execute("DROP INDEX watson_searchentry_title ON watson_searchentry")
         cursor.execute("DROP INDEX watson_searchentry_description ON watson_searchentry")
         cursor.execute("DROP INDEX watson_searchentry_content ON watson_searchentry")
-    
+
     supports_prefix_matching = True
-    
+
     requires_installation = True
-    
+
     supports_ranking = True
 
     def _format_query(self, search_text):
         return escape_mysql_boolean_query(search_text)
-    
+
     def do_search(self, engine_slug, queryset, search_text):
         """Performs the full text search."""
         return queryset.extra(
-            where = ("MATCH (title, description, content) AGAINST (%s IN BOOLEAN MODE)",),
-            params = (self._format_query(search_text),),
+            where=("MATCH (title, description, content) AGAINST (%s IN BOOLEAN MODE)",),
+            params=(self._format_query(search_text),),
         )
-        
+
     def do_search_ranking(self, engine_slug, queryset, search_text):
         """Performs full text ranking."""
         search_text = self._format_query(search_text)
         return queryset.extra(
-            select = {
+            select={
                 "watson_rank": """
                     ((MATCH (title) AGAINST (%s IN BOOLEAN MODE)) * 3) +
                     ((MATCH (description) AGAINST (%s IN BOOLEAN MODE)) * 2) +
                     ((MATCH (content) AGAINST (%s IN BOOLEAN MODE)) * 1)
                 """,
             },
-            select_params = (search_text, search_text, search_text,),
-            order_by = ("-watson_rank",),
+            select_params=(search_text, search_text, search_text,),
+            order_by=("-watson_rank",),
         )
-        
+
     def do_filter(self, engine_slug, queryset, search_text):
         """Performs the full text filter."""
         model = queryset.model
@@ -411,33 +483,33 @@ class MySQLSearchBackend(SearchBackend):
         else:
             ref_name = "object_id"
         return queryset.extra(
-            tables = ("watson_searchentry",),
-            where = (
+            tables=("watson_searchentry",),
+            where=(
                 "watson_searchentry.engine_slug = %s",
                 "MATCH (watson_searchentry.title, watson_searchentry.description, watson_searchentry.content) AGAINST (%s IN BOOLEAN MODE)",
                 "watson_searchentry.{ref_name} = {table_name}.{pk_name}".format(
-                    ref_name = ref_name,
-                    table_name = connection.ops.quote_name(model._meta.db_table),
-                    pk_name = connection.ops.quote_name(pk.db_column or pk.attname),
+                    ref_name=ref_name,
+                    table_name=connection.ops.quote_name(model._meta.db_table),
+                    pk_name=connection.ops.quote_name(pk.db_column or pk.attname),
                 ),
                 "watson_searchentry.content_type_id = %s",
             ),
-            params = (engine_slug, self._format_query(search_text), content_type.id),
+            params=(engine_slug, self._format_query(search_text), content_type.id),
         )
-        
+
     def do_filter_ranking(self, engine_slug, queryset, search_text):
         """Performs the full text ranking."""
         search_text = self._format_query(search_text)
         return queryset.extra(
-            select = {
+            select={
                 "watson_rank": """
                     ((MATCH (watson_searchentry.title) AGAINST (%s IN BOOLEAN MODE)) * 3) +
                     ((MATCH (watson_searchentry.description) AGAINST (%s IN BOOLEAN MODE)) * 2) +
                     ((MATCH (watson_searchentry.content) AGAINST (%s IN BOOLEAN MODE)) * 1)
                 """,
             },
-            select_params = (search_text, search_text, search_text,),
-            order_by = ("-watson_rank",),
+            select_params=(search_text, search_text, search_text,),
+            order_by=("-watson_rank",),
         )
 
 
@@ -445,15 +517,14 @@ def get_postgresql_version(connection):
     """Returns the version number of the PostgreSQL connection."""
     from django.db.backends.postgresql_psycopg2.version import get_version
     return get_version(connection)
-        
-        
-class AdaptiveSearchBackend(SearchBackend):
 
+
+class AdaptiveSearchBackend(SearchBackend):
     """
     A search backend that guesses the correct search backend based on the
     DATABASES["default"] settings.
     """
-    
+
     def __new__(cls):
         """Guess the correct search backend and initialize it."""
         if connection.vendor == "postgresql":

--- a/src/watson/registration.py
+++ b/src/watson/registration.py
@@ -614,7 +614,7 @@ def get_backend(backend_name=None):
         return _backends_cache[backend_name]
     # Load the backend class.
     if not backend_name:
-        backend_name = getattr(settings, "WATSON_BACKEND", "watson.backends.AdaptiveSearchBackend")
+        backend_name = getattr(settings, "WATSON_BACKEND", None) or "watson.backends.AdaptiveSearchBackend"
     backend_module_name, backend_cls_name = backend_name.rsplit(".", 1)
     backend_module = import_module(backend_module_name)
     try:


### PR DESCRIPTION
Awesome library! I started implementing support for [Postgres trigrams](http://www.postgresql.org/docs/current/static/pgtrgm.html), but I couldn't get all the tests to pass (it does function correctly though). Trigrams are awesome for small text fields, for example one of our apps uses django-watson to search a model with 10-20 characters of content and for this trigrams allow small typos and low overhead (no extra tsv_column). But with bigger fields they quickly become useless.

I'm including this MR in case you find it useful, I think it would be cool to have as an option in the library, but unfortunately I don't have the time to progress any further with this. Because trigrams are index based they could be included on just the 'title' column, which is generally going to be more suited to trigrams than the description one. Not sure how this would tie into the existing `.filter` and `.query` functions though.

Apologies for the large number of changes, Pycharm decided to reformat the backends.py. [The magic happens here](https://github.com/etianen/django-watson/pull/140/files#diff-aeb8a6a3da393863e446ba2ca55d971dR293).
