### PR TITLE
Fixing Django 1.10 Deprecation Warnings.

### DIFF
--- a/src/watson/management/commands/installwatson.py
+++ b/src/watson/management/commands/installwatson.py
@@ -11,7 +11,7 @@ class Command(BaseCommand):
 
     help = "Creates the database indices needed by django-watson."
 
-    def handle_noargs(self, **options):
+    def handle(self, *args, **options):
         """Runs the management command."""
         verbosity = int(options.get("verbosity", 1))
         backend = get_backend()

--- a/src/watson/management/commands/installwatson.py
+++ b/src/watson/management/commands/installwatson.py
@@ -2,12 +2,12 @@
 
 from __future__ import unicode_literals
 
-from django.core.management.base import NoArgsCommand
+from django.core.management.base import BaseCommand
 
 from watson.search import get_backend
 
 
-class Command(NoArgsCommand):
+class Command(BaseCommand):
 
     help = "Creates the database indices needed by django-watson."
 

--- a/src/watson/management/commands/listwatson.py
+++ b/src/watson/management/commands/listwatson.py
@@ -7,7 +7,7 @@ class Command(BaseCommand):
 
     help = "List all registed models by django-watson."
 
-    def handle_noargs(self, **options):
+    def handle(self, *args, **options):
         """Runs the management command."""
         self.stdout.write("The following models are registed for the django-watson search engine:\n")
         for mdl in watson.get_registered_models():

--- a/src/watson/management/commands/listwatson.py
+++ b/src/watson/management/commands/listwatson.py
@@ -1,9 +1,9 @@
 """Exposed the watson.get_registered_models() function as management command for debugging purpose. """
 
-from django.core.management.base import NoArgsCommand
+from django.core.management.base import BaseCommand
 from watson import search as watson
 
-class Command(NoArgsCommand):
+class Command(BaseCommand):
 
     help = "List all registed models by django-watson."
 

--- a/src/watson/management/commands/uninstallwatson.py
+++ b/src/watson/management/commands/uninstallwatson.py
@@ -2,12 +2,12 @@
 
 from __future__ import unicode_literals
 
-from django.core.management.base import NoArgsCommand
+from django.core.management.base import BaseCommand
 
 from watson.search import get_backend
 
 
-class Command(NoArgsCommand):
+class Command(BaseCommand):
 
     help = "Destroys the database indices needed by django-watson."
 

--- a/src/watson/management/commands/uninstallwatson.py
+++ b/src/watson/management/commands/uninstallwatson.py
@@ -11,7 +11,7 @@ class Command(BaseCommand):
 
     help = "Destroys the database indices needed by django-watson."
 
-    def handle_noargs(self, **options):
+    def handle(self, *args, **options):
         """Runs the management command."""
         verbosity = int(options.get("verbosity", 1))
         backend = get_backend()

--- a/src/watson/urls.py
+++ b/src/watson/urls.py
@@ -4,11 +4,12 @@ from __future__ import unicode_literals
 
 from django.conf.urls import url, patterns
 
+from watson.views import search, search_json
 
-urlpatterns = patterns("watson.views",
+urlpatterns = [
 
-    url("^$", "search", name="search"),
+    url("^$", search, name="search"),
     
-    url("^json/$", "search_json", name="search_json"),
+    url("^json/$", search_json, name="search_json"),
 
-)
+]


### PR DESCRIPTION
The pull request silences the DeprecationWarnings I'm getting on Django 1.9.1.

I'm not sure if this affects backwards compatibility but I don't think so. 

Should resolve #147 and #106 