### PR TITLE
Added --database option to tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,12 @@ env:
   - DJANGO=django==1.7.11
   - DJANGO=django==1.7.11 DB_ENGINE="django.db.backends.postgresql_psycopg2" DB_NAME="test_project" DB_USER="postgres"
   - DJANGO=django==1.7.11 DB_ENGINE="django.db.backends.mysql" DB_NAME="test_project" DB_USER="travis"
-  - DJANGO=django==1.8.7
-  - DJANGO=django==1.8.7 DB_ENGINE="django.db.backends.postgresql_psycopg2" DB_NAME="test_project" DB_USER="postgres"
-  - DJANGO=django==1.8.7 DB_ENGINE="django.db.backends.mysql" DB_NAME="test_project" DB_USER="travis"
-  - DJANGO=django==1.9.0
-  - DJANGO=django==1.9.0 DB_ENGINE="django.db.backends.postgresql" DB_NAME="test_project" DB_USER="postgres"
-  - DJANGO=django==1.9.0 DB_ENGINE="django.db.backends.mysql" DB_NAME="test_project" DB_USER="travis"
+  - DJANGO=django==1.8.12
+  - DJANGO=django==1.8.12 DB_ENGINE="django.db.backends.postgresql_psycopg2" DB_NAME="test_project" DB_USER="postgres"
+  - DJANGO=django==1.8.12 DB_ENGINE="django.db.backends.mysql" DB_NAME="test_project" DB_USER="travis"
+  - DJANGO=django==1.9.5
+  - DJANGO=django==1.9.5 DB_ENGINE="django.db.backends.postgresql" DB_NAME="test_project" DB_USER="postgres"
+  - DJANGO=django==1.9.5 DB_ENGINE="django.db.backends.mysql" DB_NAME="test_project" DB_USER="travis"
 matrix:
   exclude:
     - python: 3.5

--- a/src/tests/runtests.py
+++ b/src/tests/runtests.py
@@ -2,45 +2,78 @@
 import sys, os, os.path
 from optparse import OptionParser
 
+AVAILABLE_DATABASES = {
+    'psql': {'ENGINE': 'django.db.backends.postgresql_psycopg2'},
+    'mysql': {'ENGINE': 'django.db.backends.mysql'},
+    'sqlite': {'ENGINE': 'django.db.backends.sqlite3'},
+}
+
 
 def main():
     # Parse the command-line options.
     parser = OptionParser()
-    parser.add_option("-v", "--verbosity",
-        action = "store",
-        dest = "verbosity",
-        default = "1",
-        type = "choice",
-        choices = ["0", "1", "2", "3"],
-        help = "Verbosity level; 0=minimal output, 1=normal output, 2=all output",
+    parser.add_option(
+        "-v", "--verbosity",
+        action="store",
+        dest="verbosity",
+        default="1",
+        type="choice",
+        choices=["0", "1", "2", "3"],
+        help="Verbosity level; 0=minimal output, 1=normal output, 2=all output",
     )
-    parser.add_option("--noinput",
-        action = "store_false",
-        dest = "interactive",
-        default = True,
-        help = "Tells Django to NOT prompt the user for input of any kind.",
+    parser.add_option(
+        "--noinput",
+        action="store_false",
+        dest="interactive",
+        default=True,
+        help="Tells Django to NOT prompt the user for input of any kind.",
     )
-    parser.add_option("--failfast",
-        action = "store_true",
-        dest = "failfast",
-        default = False,
-        help = "Tells Django to stop running the test suite after first failed test.",
+    parser.add_option(
+        "--failfast",
+        action="store_true",
+        dest="failfast",
+        default=False,
+        help="Tells Django to stop running the test suite after first failed test.",
+    )
+    parser.add_option(
+        "-d", "--database",
+        action="store",
+        dest="database",
+        default="sqlite",
+        type="choice",
+        choices=list(AVAILABLE_DATABASES.keys()),
+        help="Select database backend for tests. Available choices: {}".format(
+            ', '.join(AVAILABLE_DATABASES.keys())),
     )
     options, args = parser.parse_args()
     # Configure Django.
     from django.conf import settings
+
+    # database settings
+    if options.database:
+        database_setting = AVAILABLE_DATABASES[options.database]
+        if options.database == "sqlite":
+            database_default_name = os.path.join(os.path.dirname(__file__), "db.sqlite3")
+        else:
+            database_default_name = "test_project"
+        database_setting.update(dict(
+            NAME=os.environ.get("DB_NAME", database_default_name),
+            USER=os.environ.get("DB_USER", ""),
+            PASSWORD=os.environ.get("DB_PASSWORD", "")))
+    else:
+        database_setting = dict(
+            ENGINE=os.environ.get("DB_ENGINE", 'django.db.backends.sqlite3'),
+            NAME=os.environ.get("DB_NAME", os.path.join(os.path.dirname(__file__), "db.sqlite3")),
+            USER=os.environ.get("DB_USER", ""),
+            PASSWORD=os.environ.get("DB_PASSWORD", ""))
+
     settings.configure(
-        DEBUG = False,
-        DATABASES = {
-            "default": {
-                "ENGINE": os.environ.get("DB_ENGINE", 'django.db.backends.sqlite3'),
-                "NAME": os.environ.get("DB_NAME", os.path.join(os.path.dirname(__file__), 'db.sqlite3')),
-                "USER": os.environ.get("DB_USER", ""),
-                "PASSWORD": os.environ.get("DB_PASSWORD", ""),
-            }
+        DEBUG=False,
+        DATABASES={
+            "default": database_setting
         },
-        ROOT_URLCONF = "urls",
-        INSTALLED_APPS = (
+        ROOT_URLCONF="urls",
+        INSTALLED_APPS=(
             "django.contrib.auth",
             "django.contrib.contenttypes",
             "django.contrib.sessions",
@@ -51,15 +84,15 @@ def main():
             "watson",
             "test_watson",
         ),
-        MIDDLEWARE_CLASSES = (
+        MIDDLEWARE_CLASSES=(
             "django.middleware.common.CommonMiddleware",
             "django.contrib.sessions.middleware.SessionMiddleware",
             "django.contrib.auth.middleware.AuthenticationMiddleware",
             "django.contrib.messages.middleware.MessageMiddleware",
         ),
-        USE_TZ = True,
-        STATIC_URL = "/static/",
-        TEST_RUNNER = "django.test.runner.DiscoverRunner",
+        USE_TZ=True,
+        STATIC_URL="/static/",
+        TEST_RUNNER="django.test.runner.DiscoverRunner",
     )
     # Run Django setup (1.7+).
     import django


### PR DESCRIPTION
Hey Dave,
I've added --database option to fast select database for tests.
Works better for me than changing env.variables.
For example, you can
`./runtests.py -d psql`
for running postgresql engine.

Of course, old method would work if you don't select any option.

Also, updated Django minor versions in travis config.
