### PR TITLE
removing patterns import

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,6 @@ cache:
   directories:
     - $HOME/.cache/pip
 env:
-  - DJANGO=django==1.7.11
-  - DJANGO=django==1.7.11 DB_ENGINE="django.db.backends.postgresql_psycopg2" DB_NAME="test_project" DB_USER="postgres"
-  - DJANGO=django==1.7.11 DB_ENGINE="django.db.backends.mysql" DB_NAME="test_project" DB_USER="travis"
   - DJANGO=django==1.8.14
   - DJANGO=django==1.8.14 DB_ENGINE="django.db.backends.postgresql_psycopg2" DB_NAME="test_project" DB_USER="postgres"
   - DJANGO=django==1.8.14 DB_ENGINE="django.db.backends.mysql" DB_NAME="test_project" DB_USER="travis"
@@ -21,13 +18,6 @@ env:
   - DJANGO=django==1.10 DB_ENGINE="django.db.backends.postgresql" DB_NAME="test_project" DB_USER="postgres"
   - DJANGO=django==1.10 DB_ENGINE="django.db.backends.mysql" DB_NAME="test_project" DB_USER="travis"
 matrix:
-  exclude:
-    - python: 3.5
-      env: DJANGO=django==1.7.11
-    - python: 3.5
-      env: DJANGO=django==1.7.11 DB_ENGINE="django.db.backends.postgresql_psycopg2" DB_NAME="test_project" DB_USER="postgres"
-    - python: 3.5
-      env: DJANGO=django==1.7.11 DB_ENGINE="django.db.backends.mysql" DB_NAME="test_project" DB_USER="travis"
   fast_finish: true
 services:
   - postgresql

--- a/src/tests/runtests.py
+++ b/src/tests/runtests.py
@@ -72,7 +72,7 @@ def main():
         DATABASES={
             "default": database_setting
         },
-        ROOT_URLCONF="urls",
+        ROOT_URLCONF='test_watson.urls',
         INSTALLED_APPS=(
             "django.contrib.auth",
             "django.contrib.contenttypes",
@@ -93,6 +93,12 @@ def main():
         USE_TZ=True,
         STATIC_URL="/static/",
         TEST_RUNNER="django.test.runner.DiscoverRunner",
+        TEMPLATES=[{
+            'BACKEND': 'django.template.backends.django.DjangoTemplates',
+            'DIRS': ['templates'],
+            'APP_DIRS': True,
+        }], 
+        
     )
     # Run Django setup (1.7+).
     import django

--- a/src/tests/test_watson/tests.py
+++ b/src/tests/test_watson/tests.py
@@ -30,6 +30,17 @@ from watson.backends import escape_query
 from test_watson.models import WatsonTestModel1, WatsonTestModel2
 from test_watson import admin  # Force early registration of all admin models.
 
+# test settings to override
+SETTINGS_OVERRIDE = {
+    'TEMPLATES': [
+        {
+            'BACKEND': 'django.template.backends.django.DjangoTemplates',
+            'DIRS': ['templates'],
+            'APP_DIRS': True,
+        },
+    ], 
+    'ROOT_URLCONF': 'test_watson.urls',
+}
 
 class RegistrationTest(TestCase):
 
@@ -560,7 +571,7 @@ class ComplexRegistrationTest(SearchTestBase):
         self.assertEqual(complex_registration_search_engine.filter(WatsonTestModel2, "DESCRIPTION").count(), 0)
 
 
-@override_settings(ROOT_URLCONF="test_watson.urls")
+@override_settings(**SETTINGS_OVERRIDE)
 class AdminIntegrationTest(SearchTestBase):
     
     def setUp(self):
@@ -600,9 +611,8 @@ class AdminIntegrationTest(SearchTestBase):
         del self.user
 
 
-@override_settings(ROOT_URLCONF="test_watson.urls")
+@override_settings(**SETTINGS_OVERRIDE)
 class SiteSearchTest(SearchTestBase):
-
     def testSiteSearch(self):
         # Test a search than should find everything.
         response = self.client.get("/simple/?q=title")

--- a/src/tests/test_watson/tests.py
+++ b/src/tests/test_watson/tests.py
@@ -16,7 +16,6 @@ except:
     from django.utils.unittest import skipUnless
 
 from django.test import TestCase
-from django.test.utils import override_settings
 from django.core.management import call_command
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -29,18 +28,6 @@ from watson.backends import escape_query
 
 from test_watson.models import WatsonTestModel1, WatsonTestModel2
 from test_watson import admin  # Force early registration of all admin models.
-
-# test settings to override
-SETTINGS_OVERRIDE = {
-    'TEMPLATES': [
-        {
-            'BACKEND': 'django.template.backends.django.DjangoTemplates',
-            'DIRS': ['templates'],
-            'APP_DIRS': True,
-        },
-    ], 
-    'ROOT_URLCONF': 'test_watson.urls',
-}
 
 class RegistrationTest(TestCase):
 
@@ -571,7 +558,6 @@ class ComplexRegistrationTest(SearchTestBase):
         self.assertEqual(complex_registration_search_engine.filter(WatsonTestModel2, "DESCRIPTION").count(), 0)
 
 
-@override_settings(**SETTINGS_OVERRIDE)
 class AdminIntegrationTest(SearchTestBase):
     
     def setUp(self):
@@ -611,7 +597,6 @@ class AdminIntegrationTest(SearchTestBase):
         del self.user
 
 
-@override_settings(**SETTINGS_OVERRIDE)
 class SiteSearchTest(SearchTestBase):
     def testSiteSearch(self):
         # Test a search than should find everything.

--- a/src/tests/test_watson/tests.py
+++ b/src/tests/test_watson/tests.py
@@ -16,6 +16,7 @@ except:
     from django.utils.unittest import skipUnless
 
 from django.test import TestCase
+from django.test.utils import override_settings
 from django.core.management import call_command
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -559,10 +560,9 @@ class ComplexRegistrationTest(SearchTestBase):
         self.assertEqual(complex_registration_search_engine.filter(WatsonTestModel2, "DESCRIPTION").count(), 0)
 
 
+@override_settings(ROOT_URLCONF="test_watson.urls")
 class AdminIntegrationTest(SearchTestBase):
-
-    urls = "test_watson.urls"
-
+    
     def setUp(self):
         super(AdminIntegrationTest, self).setUp()
         self.user = User(
@@ -600,9 +600,8 @@ class AdminIntegrationTest(SearchTestBase):
         del self.user
 
 
+@override_settings(ROOT_URLCONF="test_watson.urls")
 class SiteSearchTest(SearchTestBase):
-
-    urls = "test_watson.urls"
 
     def testSiteSearch(self):
         # Test a search than should find everything.

--- a/src/tests/test_watson/urls.py
+++ b/src/tests/test_watson/urls.py
@@ -1,8 +1,8 @@
-from django.conf.urls import patterns, url, include
+from django.conf.urls import url, include
 from django.contrib import admin
 
 
-urlpatterns = patterns("",
+urlpatterns = [
 
     url("^simple/", include("watson.urls")),
     
@@ -17,5 +17,4 @@ urlpatterns = patterns("",
     }),
     
     url("^admin/", include(admin.site.urls)),
-
-)
+]

--- a/src/tests/urls.py
+++ b/src/tests/urls.py
@@ -4,7 +4,4 @@ should be added within the test folders, and use TestCase.urls to set them.
 This helps the tests remain isolated.
 """
 
-from django.conf.urls import patterns
-
-
-urlpatterns = patterns("")
+urlpatterns = []

--- a/src/watson/management/commands/buildwatson.py
+++ b/src/watson/management/commands/buildwatson.py
@@ -82,7 +82,7 @@ class Command(BaseCommand):
         # get the search engine we'll be checking registered models for, may be "default"
         search_engine = get_engine(engine_slug)
         models = []
-        for model_name in options['apps']:
+        for model_name in options.get('apps', []):
             try:
                 model = apps.get_model(*model_name.split("."))  # app label, model name
             except TypeError:  # were we given only model name without app_name?

--- a/src/watson/management/commands/buildwatson.py
+++ b/src/watson/management/commands/buildwatson.py
@@ -58,11 +58,13 @@ class Command(BaseCommand):
     args = "[[--engine=search_engine] <app.model|model> <app.model|model> ... ]"
     help = "Rebuilds the database indices needed by django-watson. You can (re-)build index for selected models by specifying them"
 
-    option_list = BaseCommand.option_list + (
-        make_option("--engine",
-            help="Search engine models are registered with"),
+    def add_arguments(self, parser):
+        parser.add_argument("apps", nargs="*", action="store", default=[])
+        parser.add_argument('--engine',
+            action="store",
+            help='Search engine models are registered with'
         )
-
+    
     @transaction.atomic()
     def handle(self, *args, **options):
         """Runs the management command."""
@@ -76,12 +78,11 @@ class Command(BaseCommand):
         else:
             engine_slug = "default"
             engine_selected = False
-
+        
         # get the search engine we'll be checking registered models for, may be "default"
         search_engine = get_engine(engine_slug)
-
         models = []
-        for model_name in args:
+        for model_name in options['apps']:
             try:
                 model = apps.get_model(*model_name.split("."))  # app label, model name
             except TypeError:  # were we given only model name without app_name?

--- a/src/watson/management/commands/buildwatson.py
+++ b/src/watson/management/commands/buildwatson.py
@@ -70,9 +70,9 @@ class Command(BaseCommand):
         """Runs the management command."""
         activate(settings.LANGUAGE_CODE)
         verbosity = int(options.get("verbosity", 1))
-
+        
         # see if we're asked to use a specific search engine
-        if options['engine']:
+        if options.get('engine'):
             engine_slug = options['engine']
             engine_selected = True
         else:

--- a/src/watson/management/commands/buildwatson.py
+++ b/src/watson/management/commands/buildwatson.py
@@ -79,10 +79,16 @@ class Command(BaseCommand):
             engine_slug = "default"
             engine_selected = False
         
+        # work-around for legacy optparser hack in BaseCommand. In Django=1.10 the
+        # args are collected in options['apps'], but in earlier versions they are
+        # kept in args.
+        if len(options['apps']): 
+            args = options['apps']
+        
         # get the search engine we'll be checking registered models for, may be "default"
         search_engine = get_engine(engine_slug)
         models = []
-        for model_name in options.get('apps', []):
+        for model_name in args:
             try:
                 model = apps.get_model(*model_name.split("."))  # app label, model name
             except TypeError:  # were we given only model name without app_name?

--- a/src/watson/urls.py
+++ b/src/watson/urls.py
@@ -2,7 +2,7 @@
 
 from __future__ import unicode_literals
 
-from django.conf.urls import url, patterns
+from django.conf.urls import url
 
 from watson.views import search, search_json
 


### PR DESCRIPTION
urls.py raises the following ImportError on Django 1.10:

```
  File "/Users/simon/files/Projects/language5/env/lib/python2.7/site-packages/watson/urls.py", line 5, in <module>
    from django.conf.urls import url, patterns
ImportError: cannot import name patterns
```

... and `patterns` isn't needed, so this removes the offending import.

Also, I think https://github.com/etianen/django-watson/pull/148 can be closed as outdated/fixed.