### PR TITLE
Fix Django 1.10 error when trying to import the deprecated patterns.

### DIFF
--- a/src/watson/urls.py
+++ b/src/watson/urls.py
@@ -2,7 +2,7 @@
 
 from __future__ import unicode_literals
 
-from django.conf.urls import url, patterns
+from django.conf.urls import url
 
 from watson.views import search, search_json
 


### PR DESCRIPTION
Fix Django 1.10 error when trying to import the deprecated django.conf.urls.patterns. The patterns is not used in its source code anyway.