### PR TITLE
Optionnal parameter added to return all objects for a blank search

### DIFF
--- a/watson/search.py
+++ b/watson/search.py
@@ -574,12 +574,12 @@ class SearchEngine(object):
                 else:
                     yield queryset.all()
 
-    def search(self, search_text, models=(), exclude=(), ranking=True, backend_name=None):
+    def search(self, search_text, models=(), exclude=(), ranking=True, backend_name=None, blank_search_results=False):
         """Performs a search using the given text, returning a queryset of SearchEntry."""
         from watson.models import SearchEntry
         # Check for blank search text.
         search_text = search_text.strip()
-        if not search_text:
+        if not search_text and not blank_search_results:
             return SearchEntry.objects.none()
         # Get the initial queryset.
         queryset = SearchEntry.objects.filter(
@@ -591,6 +591,9 @@ class SearchEngine(object):
         ).exclude(
             self._create_model_filter(exclude)
         )
+        # Return queryset for the blank search text
+        if not search_text and blank_search_results:
+            return queryset
         # Perform the backend-specific full text match.
         backend = get_backend(backend_name=backend_name)
         queryset = backend.do_search(self._engine_slug, queryset, search_text)


### PR DESCRIPTION
I need to be able to return all results even if the query is blank.

This patch adds an optional bool parameter 'blank_search_results' to search(). When set to True, it will return all the objects.

Ex. of usage:
```
from watson import search as watson

query = ''

# Will return all Watson registered models objects.
search_results = watson.search(query, blank_search_results=True)

# Will return all Your_models objects.
search_results = watson.filter(Your_model, query, blank_search_results=True)

```