### PR TITLE
Re-enable Python 3.6 in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: python
 sudo: false
 python:
+  - 2.7
+  - 3.4
   - 3.5
+  - 3.6
 cache:
   directories:
     - $HOME/.cache/pip
@@ -9,7 +12,7 @@ services:
   - postgresql
   - mysql
 install:
-  - pip install tox
+  - pip install tox-travis
 before_script:
   - mysql -e 'create database test_project';
   - psql -c 'create database test_project;' -U postgres;

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 sudo: false
 python:
   - 2.7
+  - 3.3
   - 3.4
   - 3.5
   - 3.6

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist =
     coverage-erase
     {py27,py34,py35}-django{18,19,110,111}-{sqlite,postgres,mysql}
+    py36-django111-{sqlite,postgres,mysql}
     coverage-report
     flake8
 
@@ -21,6 +22,13 @@ commands =
     postgres: coverage run -a tests/runtests.py -d psql
     mysql: coverage run -a tests/runtests.py -d mysql
     coverage-report: coverage report
+
+[travis]
+python =
+    2.7: py27
+    3.4: py34
+    3.5: py35, flake8
+    3.6: py36
 
 [flake8]
 max-line-length=120

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist =
     begin
+    py33-django18-{sqlite,postgres,mysql}
     {py27,py34,py35}-django{18,19,110,111}-{sqlite,postgres,mysql}
     py36-django111-{sqlite,postgres,mysql}
     end
@@ -26,6 +27,7 @@ commands =
 [travis]
 python =
     2.7: begin, py27, end
+    3.3: begin, py33, end
     3.4: begin, py34, end
     3.5: begin, py35, end, flake8
     3.6: begin, py36, end

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
-    coverage-erase
+    begin
     {py27,py34,py35}-django{18,19,110,111}-{sqlite,postgres,mysql}
     py36-django111-{sqlite,postgres,mysql}
-    coverage-report
+    end
     flake8
 
 [testenv]
@@ -17,18 +17,18 @@ deps =
     postgres: psycopg2
     mysql: mysqlclient
 commands =
-    coverage-erase: coverage erase
+    begin: coverage erase
     sqlite: coverage run -a tests/runtests.py
     postgres: coverage run -a tests/runtests.py -d psql
     mysql: coverage run -a tests/runtests.py -d mysql
-    coverage-report: coverage report
+    end: coverage report
 
 [travis]
 python =
-    2.7: py27
-    3.4: py34
-    3.5: py35, flake8
-    3.6: py36
+    2.7: begin, py27, end
+    3.4: begin, py34, end
+    3.5: begin, py35, end, flake8
+    3.6: begin, py36, end
 
 [flake8]
 max-line-length=120


### PR DESCRIPTION
These changes use [tox-travis](https://pypi.python.org/pypi/tox-travis) to run tests in their specific Python versions and work around the issues I was having in #205 . Additionally, I've added Python 3.3 to the env list for full Django 1.8 testing.