### PR TITLE
Avoid "RemovedInDjango20Warning: on_delete will be a required arg for ForeignKey in Django 2.0" with recent versions of Django

### DIFF
--- a/watson/migrations/0001_initial.py
+++ b/watson/migrations/0001_initial.py
@@ -32,7 +32,7 @@ class Migration(migrations.Migration):
                 ('content', models.TextField(blank=True)),
                 ('url', models.CharField(max_length=1000, blank=True)),
                 ('meta_encoded', models.TextField()),
-                ('content_type', models.ForeignKey(to='contenttypes.ContentType')),
+                ('content_type', models.ForeignKey(to='contenttypes.ContentType', on_delete=models.CASCADE)),
             ],
             options={
                 'verbose_name_plural': 'search entries',

--- a/watson/models.py
+++ b/watson/models.py
@@ -40,6 +40,7 @@ class SearchEntry(models.Model):
 
     content_type = models.ForeignKey(
         ContentType,
+        on_delete = models.CASCADE,
     )
 
     object_id = models.TextField()

--- a/watson/models.py
+++ b/watson/models.py
@@ -40,7 +40,7 @@ class SearchEntry(models.Model):
 
     content_type = models.ForeignKey(
         ContentType,
-        on_delete = models.CASCADE,
+        on_delete=models.CASCADE,
     )
 
     object_id = models.TextField()


### PR DESCRIPTION
As explained [in documentation](https://docs.djangoproject.com/en/1.11/ref/models/fields/#django.db.models.ForeignKey.on_delete),  `on_delete` argument in `models.ForeignKey()` will become required starting from Django 2.0. Since Django 1.9 and higher thrown a warning when it is missing, it should be always set.
Note: on Django 1.11, warning is visible only with -W command line argument. Example: `python -Wd manage.py runserver`

When the argument is omitted, the default value is `CASCADE`. So it is safe to set this value to `models.CASCADE`.