### PR TITLE
"Slim" Indexing

### DIFF
--- a/watson/management/commands/buildwatson.py
+++ b/watson/management/commands/buildwatson.py
@@ -81,14 +81,14 @@ class Command(BaseCommand):
             help='Search engine models are registered with'
         )
         parser.add_argument(
-            '--slim', 
-            action='store_true', 
-            default=False, 
+            '--slim',
+            action='store_true',
+            default=False,
             help="Only include objects which satisfy the filter specified during \
             model registration. WARNING: buildwatson must be rerun if the filter \
             changes or the index will be incomplete."
         )
-        
+
     @transaction.atomic()
     def handle(self, *args, **options):
         """Runs the management command."""

--- a/watson/management/commands/buildwatson.py
+++ b/watson/management/commands/buildwatson.py
@@ -28,7 +28,7 @@ def get_engine(engine_slug_):
         raise CommandError("Search Engine \"%s\" is not registered!" % force_text(engine_slug_))
 
 
-def rebuild_index_for_model(model_, engine_slug_, verbosity_):
+def rebuild_index_for_model(model_, engine_slug_, verbosity_, slim_=False):
     """rebuilds index for a model"""
 
     search_engine_ = get_engine(engine_slug_)
@@ -74,6 +74,14 @@ class Command(BaseCommand):
             action="store",
             help='Search engine models are registered with'
         )
+        parser.add_argument(
+            '--slim', 
+            action='store_true', 
+            default=False, 
+            help="Only include objects which satisfy the filter specified during \
+            model registration. WARNING: buildwatson must be rerun if the filter \
+            changes or the index will be incomplete."
+        )
 
     @transaction.atomic()
     def handle(self, *args, **options):
@@ -88,6 +96,9 @@ class Command(BaseCommand):
         else:
             engine_slug = "default"
             engine_selected = False
+
+        # Do we do a partial index?
+        slim = options.get("slim")
 
         # work-around for legacy optparser hack in BaseCommand. In Django=1.10 the
         # args are collected in options['apps'], but in earlier versions they are
@@ -123,7 +134,7 @@ class Command(BaseCommand):
             if verbosity >= 3:
                 print("Using search engine \"%s\"" % engine_slug)
             for model in models:
-                refreshed_model_count += rebuild_index_for_model(model, engine_slug, verbosity)
+                refreshed_model_count += rebuild_index_for_model(model, engine_slug, verbosity, slim_=slim)
 
         else:  # full rebuild (for one or all search engines)
             if engine_selected:
@@ -139,7 +150,7 @@ class Command(BaseCommand):
                 registered_models = search_engine.get_registered_models()
                 # Rebuild the index for all registered models.
                 for model in registered_models:
-                    refreshed_model_count += rebuild_index_for_model(model, engine_slug, verbosity)
+                    refreshed_model_count += rebuild_index_for_model(model, engine_slug, verbosity, slim_=slim)
 
                 # Clean out any search entries that exist for stale content types.
                 # Only do it during full rebuild


### PR DESCRIPTION
I added an option to `buildwatson` for only indexing records which match the filter applied during the `search.register` process.

This option can be selected by `./manage.py buildwatson --slim`

I see the prudence of indexing all records to prevent holes in the search index when modifying the register filter, so I left that behavior as the default. On the other hand, I have some tables that have millions of records, including legacy data, where I only need to search 1/10-2/3 of the data, so this should save a significant amount of time. 