### PR TITLE
WIP: Support multilingual searches

### DIFF
--- a/watson/__init__.py
+++ b/watson/__init__.py
@@ -6,4 +6,4 @@ Developed by Dave Hall.
 <http://www.etianen.com/>
 """
 
-__version__ = VERSION = (1, 5, 2)
+__version__ = VERSION = (1, 5, 3)


### PR DESCRIPTION
An attempt to refactor the library to make multilingual searches works for #248 


I'm not sure, but seems like the build watson command isn't indexing the SearchEntry properly.

I'm using a different configuration for chinese. I see that buildwatson command activates the particular language before doing anything, but how does it know which parser to use before indexing the data.

@etianen Can you please help?