### PR TITLE
Point PyPI badge at correct project

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -2,7 +2,7 @@ django-watson
 =============
 
 [![Build Status](https://travis-ci.org/etianen/django-watson.svg?branch=master)](https://travis-ci.org/etianen/django-watson)
-[![PyPI](https://img.shields.io/pypi/v/nine.svg)](https://pypi.python.org/pypi/django-watson)
+[![PyPI](https://img.shields.io/pypi/v/django-watson.svg)](https://pypi.python.org/pypi/django-watson)
 [![GitHub license](https://img.shields.io/badge/license-New%20BSD-blue.svg)](https://raw.githubusercontent.com/etianen/django-watson/master/LICENSE)
 
 **django-watson** is a fast multi-model full-text search plugin for Django.


### PR DESCRIPTION
Currently this badge is displaying "v1.0.0" rather than "v1.5.2".