### PR TITLE
Escape '@' on MySQL

### DIFF
--- a/watson/backends.py
+++ b/watson/backends.py
@@ -25,8 +25,8 @@ def regex_from_word(word):
 
 # PostgreSQL to_tsquery operators: ! & : ( ) |
 RE_POSTGRES_ESCAPE_CHARS = re.compile(r'[&:(|)!><]', re.UNICODE)
-# MySQL boolean full-text search operators: > < ( ) " ~ * + -
-RE_MYSQL_ESCAPE_CHARS = re.compile(r'["()><~*+-]', re.UNICODE)
+# MySQL boolean full-text search operators: > < ( ) " ~ * + - @
+RE_MYSQL_ESCAPE_CHARS = re.compile(r'["()><~*+-@]', re.UNICODE)
 
 RE_SPACE = re.compile(r"[\s]+", re.UNICODE)
 


### PR DESCRIPTION
The '@' character needs escaping in the MySQL backend since `@distance` was introduced.

Reference: <https://dev.mysql.com/doc/refman/5.7/en/fulltext-boolean.html>
