### PR TITLE
[BUGFIX] Fixed buildwatson error with no admin installed

### DIFF
--- a/watson/management/commands/buildwatson.py
+++ b/watson/management/commands/buildwatson.py
@@ -17,7 +17,8 @@ from watson.models import SearchEntry
 
 
 # Sets up registration for django-watson's admin integration.
-admin.autodiscover()
+if apps.is_installed("django.contrib.admin"):
+    admin.autodiscover()
 
 
 def get_engine(engine_slug_):


### PR DESCRIPTION
Buildwatson gives crashes on following error when admin is not installed:

LookupError: No installed app with label 'admin'