### PR TITLE
[BUGFIX] #255 Fixed MySQL tests failing mysql + admin context

### DIFF
--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -5,7 +5,12 @@ from optparse import OptionParser
 
 AVAILABLE_DATABASES = {
     'psql': {'ENGINE': 'django.db.backends.postgresql_psycopg2'},
-    'mysql': {'ENGINE': 'django.db.backends.mysql'},
+    'mysql': {
+        'ENGINE': 'django.db.backends.mysql',
+        'OPTIONS': {
+            'init_command': "SET sql_mode='STRICT_TRANS_TABLES'"
+        },
+    },
     'sqlite': {'ENGINE': 'django.db.backends.sqlite3'},
 }
 
@@ -103,7 +108,10 @@ def main():
         TEMPLATES=[{
             'BACKEND': 'django.template.backends.django.DjangoTemplates',
             'DIRS': ['templates'],
-            'OPTIONS': {'context_processors': ['django.contrib.auth.context_processors.auth']},
+            'OPTIONS': {'context_processors': [
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+            ]},
             'APP_DIRS': True,
         }],
     )

--- a/watson/backends.py
+++ b/watson/backends.py
@@ -17,8 +17,8 @@ from watson.models import SearchEntry, has_int_pk
 
 
 def regex_from_word(word):
-    """Generates a regext from the given search word."""
-    return "(\s{word})|(^{word})".format(
+    """Generates a regex from the given search word."""
+    return r"(\s{word})|(^{word})".format(
         word=re.escape(word),
     )
 


### PR DESCRIPTION
The admin tests failed because of the following error:

(admin.E404) 'django.contrib.messages.context_processors.messages' must be enabled in DjangoTemplates (TEMPLATES) in order to use the admin application.

This is fixed by adding
'django.contrib.messages.context_processors.messages' tot the context_processors

The MySQL tests failed on the error:

django.db.utils.OperationalError: (1055, "Expression #2 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'test_test_project.watson_searchentry.title' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by")

After some diging this hapens because the qeuryset count uses an annotation/aggrogation.
https://github.com/django/django/blob/37f8f293775d0b672da8ae369d9a4e17f1db7851/django/db/models/sql/query.py#L510

Based on what django recomends for setting the sql_mode to https://docs.djangoproject.com/en/2.2/ref/databases/#setting-sql-mode. And the recomandation from
https://code.djangoproject.com/ticket/15940#comment:10 to always explicitly set the sql_mode.

I have updated the test MySQL settings to set the sql_mode to STRICT_TRANS_TABLES