### PR TITLE
django 3.0 compatibility

### DIFF
--- a/watson/backends.py
+++ b/watson/backends.py
@@ -11,7 +11,6 @@ from django.db import transaction, connections, router
 from django.db.models import Q, FloatField
 from django.db.models.expressions import RawSQL, Value
 from django.utils.encoding import force_text
-from django.utils import six
 
 from watson.models import SearchEntry, has_int_pk
 
@@ -43,7 +42,7 @@ def escape_query(text, re_escape_chars):
     return text
 
 
-class SearchBackend(six.with_metaclass(abc.ABCMeta)):
+class SearchBackend(metaclass=abc.ABCMeta):
     """Base class for all search backends."""
 
     def is_installed(self):
@@ -87,7 +86,7 @@ class SearchBackend(six.with_metaclass(abc.ABCMeta)):
         return connection.ops.quote_name(column_name)
 
 
-class RegexSearchMixin(six.with_metaclass(abc.ABCMeta)):
+class RegexSearchMixin(metaclass=abc.ABCMeta):
 
     """Mixin to adding regex search to a search backend."""
 

--- a/watson/models.py
+++ b/watson/models.py
@@ -6,7 +6,7 @@ import uuid
 
 from django.db import models
 from django.contrib.contenttypes.models import ContentType
-from django.utils.encoding import python_2_unicode_compatible, force_text
+from django.utils.encoding import force_text
 from django.utils.functional import cached_property
 
 try:
@@ -42,7 +42,6 @@ def get_str_pk(obj, connection):
 META_CACHE_KEY = "_meta_cache"
 
 
-@python_2_unicode_compatible
 class SearchEntry(models.Model):
 
     """An entry in the search index."""

--- a/watson/views.py
+++ b/watson/views.py
@@ -6,7 +6,6 @@ import json
 
 from django.shortcuts import redirect
 from django.http import HttpResponse
-from django.utils import six
 from django.views import generic
 from django.views.generic.list import BaseListView
 
@@ -66,7 +65,7 @@ class SearchMixin(object):
         context = super(SearchMixin, self).get_context_data(**kwargs)
         context["query"] = self.query
         # Process extra context.
-        for key, value in six.iteritems(self.get_extra_context()):
+        for key, value in self.get_extra_context().items():
             if callable(value):
                 value = value()
             context[key] = value


### PR DESCRIPTION
Removed references to django.utils.six and python_2_unicode_compatible because both were removed in django 3.0.