### PR TITLE
docs: Fix simple typo, thie -> this

### DIFF
--- a/watson/search.py
+++ b/watson/search.py
@@ -366,7 +366,7 @@ class SearchEngine(object):
                     engine_slug=engine_slug,
                 )
             )
-        # Initialize thie engine.
+        # Initialize this engine.
         self._registered_models = {}
         self._engine_slug = engine_slug
         # Store the search context.


### PR DESCRIPTION
There is a small typo in watson/search.py.

Should read `this` rather than `thie`.

