### PR TITLE
Add AppConfig with default_auto_field set

### DIFF
--- a/watson/apps.py
+++ b/watson/apps.py
@@ -1,0 +1,7 @@
+from django.apps import AppConfig
+
+
+class WatsonAppConfig(AppConfig):
+    """App configuration for watson."""
+    name = 'watson'
+    default_auto_field = 'django.db.models.AutoField'


### PR DESCRIPTION
Hello!

I noticed #285 and figured I would take a stab at it. I just added `apps.py` with an `AppConfig` subclass which sets the `default_auto_field` setting to `AutoField`. To my understanding, Django >= 3.2 (the versions where the warning mentioned in the issue appears) automatically loads the `AppConfig` subclass found in `apps.py`, so I think just adding this should address the issue.

resolves #285.