### PR TITLE
Add handling for RelatedField pk types

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -31,31 +31,14 @@ jobs:
       max-parallel: 4
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
-        django-version: [1.11, 2.0, 2.1, 2.2, 3.0, 3.1, 3.2]
+        django-version: [2.0, 2.1, 2.2, 3.0, 3.1, 3.2]
         exclude:
-        # Python 2.7 is compatible with Django 1.11
-        - python-version: "2.7"
-          django-version: "2.0"
-        - python-version: "2.7"
-          django-version: "2.1"
-        - python-version: "2.7"
-          django-version: "2.2"
-        - python-version: "2.7"
-          django-version: "3.0"
-        - python-version: "2.7"
-          django-version: "3.1"
-        - python-version: "2.7"
-          django-version: "3.2"
         # Python 3.8 is compatible with Django 2.2+
-        - python-version: "3.8"
-          django-version: "1.11"
         - python-version: "3.8"
           django-version: "2.0"
         - python-version: "3.8"
           django-version: "2.1"
         # Python 3.9 is compatible with Django 3.1+
-        - python-version: "3.9"
-          django-version: "1.11"
         - python-version: "3.9"
           django-version: "2.0"
         - python-version: "3.9"

--- a/watson/models.py
+++ b/watson/models.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 import uuid
 
 from django.db import models
+from django.db.models.fields.related import RelatedField
 from django.contrib.contenttypes.models import ContentType
 from django.utils.encoding import force_str
 from django.utils.functional import cached_property
@@ -27,6 +28,8 @@ except AttributeError:  # Django < 2.0.
 def get_pk_output_field(model):
     """Gets an instance of the field type for the primary key of the given model, useful for database CAST."""
     pk = model._meta.pk
+    if isinstance(pk, RelatedField):
+        return get_pk_output_field(pk.remote_field.model)
     field_cls = type(pk)
     field_kwargs = {}
     if isinstance(pk, models.CharField):


### PR DESCRIPTION
As was highlighted by #292, lack of proper handling for primary key field types which derive from `RelatedField` in `get_pk_output_field` causes errors when running `buildwatson`. This change adds a simple check to the `get_pk_output_field` function which will retrieve the field type from the related model instead, to avoid errors.

fixes #292