### PR TITLE
docs: Fix a few typos

### DIFF
--- a/tests/test_watson/tests.py
+++ b/tests/test_watson/tests.py
@@ -754,7 +754,7 @@ class SiteSearchTest(SearchTestBase):
             self.assertEqual(ex.args[0], "404.html")
         else:
             self.assertEqual(response.status_code, 404)
-        # Test a requet for the last page.
+        # Test a request for the last page.
         response = self.client.get("/custom/?fooo=title&page=last")
         self.assertEqual(response.context["paginator"].num_pages, 1)
         self.assertEqual(response.context["page_obj"].number, 1)

--- a/watson/search.py
+++ b/watson/search.py
@@ -240,7 +240,7 @@ class SearchContextManager(local):
         objects.add((engine, obj))
 
     def invalidate(self):
-        """Marks this search context as broken, so should not be commited."""
+        """Marks this search context as broken, so should not be committed."""
         self._assert_active()
         objects, _ = self._stack[-1]
         self._stack[-1] = (objects, True)


### PR DESCRIPTION
There are small typos in:
- tests/test_watson/tests.py
- watson/search.py

Fixes:
- Should read `request` rather than `requet`.
- Should read `committed` rather than `commited`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md