### PR TITLE
Change PostgresSearchBackend to optmize for UUID primary keys

### DIFF
--- a/watson/models.py
+++ b/watson/models.py
@@ -60,6 +60,12 @@ def has_int_pk(model):
     )
 
 
+def has_uuid_pk(model):
+    """Tests whether the given model has an uuid primary key."""
+    pk = model._meta.pk
+    return isinstance(pk, models.UUIDField)
+
+
 def get_str_pk(obj, connection):
     return obj.pk.hex if isinstance(obj.pk, uuid.UUID) and connection.vendor != "postgresql" else force_str(obj.pk)
 


### PR DESCRIPTION
## Context

After running some performance tests, I realized the way we are casting types for the `model primary key` vs `searchentry.object_id` was unefficient.

When we do a `model.uuid_pk::text` conversion, postgres lose the ability to use the primary key index and that makes the query way slower.


## Queries and plans (testing with 100k records)

Note the primary key index was not used because of a type cast (partnershipledger.id::text)

In nearly 100k records, the execution went from 71ms to 7ms 💯

### Before
![Screenshot 2023-01-12 at 11 37 08](https://user-images.githubusercontent.com/9268203/212100112-d48af30c-2bec-4a84-809a-18c970d64625.png)


### After
![Screenshot 2023-01-12 at 11 38 02](https://user-images.githubusercontent.com/9268203/212100193-1e6ab399-58fe-4097-9331-3fc249a80943.png)

## Proposed sollution

If the primary key is UUID, we cast type in the watson_searchentry.id instead.